### PR TITLE
No longer deployed via Github Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
-deploy: # https://docs.travis-ci.com/user/deployment/pages/
-  fqdn: time.bign8.info
-  provider: pages
-  local_dir: static
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  on:
-    branch: master
+# deploy: # https://docs.travis-ci.com/user/deployment/pages/
+#   fqdn: time.bign8.info
+#   provider: pages
+#   local_dir: static
+#   skip_cleanup: true
+#   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+#   on:
+#     branch: master
 
 sudo: false # route your build to the container-based infrastructure for a faster build


### PR DESCRIPTION
Remove travis deploy phase, as this is now hosted internally.